### PR TITLE
Converting setup.py to user Distutils directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ test:
 	rm -f .coverage
 	python3 -m pytest --cov=src/tomatinho
 
+install:
+	sudo python3 setup.py install --install-layout=deb
+
 .PHONY: all test clean

--- a/scripts/tomatinho
+++ b/scripts/tomatinho
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+from tomatinho import tomatinho
+
+if __name__ == '__main__':
+    tomatinho.main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from setuptools import setup, find_packages
+from distutils.core import setup
 
 sys.path.append('src')
 from tomatinho import appinfo
@@ -17,8 +17,6 @@ setup(
     license=appinfo.LICENSE,
     author=appinfo.AUTHOR,
     url=appinfo.SITE,
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
@@ -30,12 +28,10 @@ setup(
         'Natural Language :: English',
         'Topic :: Utilities',
     ],
-    entry_points={
-        'gui_scripts': [
-            'tomatinho=tomatinho.tomatinho:main',
-        ]
-    },
-    data_files=[('tomatinho/icons',
+    package_dir={'': 'src'},
+    packages=['tomatinho'],
+    scripts=['scripts/tomatinho'],
+    data_files=[('share/tomatinho/icons',
                  ['data/icons/tomate-idle.png',
                   'data/icons/tomate-pomo.png',
                   'data/icons/tomate-rest-l.png',

--- a/src/tomatinho/appinfo.py
+++ b/src/tomatinho/appinfo.py
@@ -17,4 +17,6 @@ SITE = 'https://github.com/meunomemauricio/tomatinho'
 
 # Application Directories
 HOME_DIR = os.path.expanduser('~')
-APP_DIR = os.path.join(HOME_DIR, '.tomatinho')
+USER_DIR = os.path.join(HOME_DIR, '.tomatinho')
+APP_DIR = '/usr/share/tomatinho'
+ICONS_DIR = os.path.join(APP_DIR, 'icons')

--- a/src/tomatinho/event_recorder.py
+++ b/src/tomatinho/event_recorder.py
@@ -28,9 +28,9 @@ class EventRecorder:
 
         :return: New connection to the DB
         """
-        if not os.path.exists(appinfo.APP_DIR):
-            os.makedirs(appinfo.APP_DIR)
-        conn = sqlite3.connect(os.path.join(appinfo.APP_DIR, 'tomatinho.db'))
+        if not os.path.exists(appinfo.USER_DIR):
+            os.makedirs(appinfo.USER_DIR)
+        conn = sqlite3.connect(os.path.join(appinfo.USER_DIR, 'tomatinho.db'))
         conn.cursor().execute(self.CREATE_QUERY)
         conn.commit()
         return conn

--- a/src/tomatinho/tomatinho.py
+++ b/src/tomatinho/tomatinho.py
@@ -2,6 +2,7 @@
 """Main Application module."""
 
 import gi
+import os.path
 import signal
 
 gi.require_version('Gtk', '3.0')
@@ -12,8 +13,6 @@ from gi.repository import Gtk
 from gi.repository import GdkPixbuf
 from gi.repository import AppIndicator3
 from gi.repository import Notify
-
-from pkg_resources import resource_filename
 
 from . import appinfo
 from . event_recorder import EventRecorder
@@ -31,10 +30,10 @@ class States:
 class Tomatinho:
     """Pomodoro Timer Application"""
 
-    ICON_IDLE = resource_filename(__name__, 'icons/tomate-idle.png')
-    ICON_POMO = resource_filename(__name__, 'icons/tomate-pomo.png')
-    ICON_REST_S = resource_filename(__name__, 'icons/tomate-rest-s.png')
-    ICON_REST_L = resource_filename(__name__, 'icons/tomate-rest-l.png')
+    ICON_IDLE = os.path.join(appinfo.ICONS_DIR, 'tomate-idle.png')
+    ICON_POMO = os.path.join(appinfo.ICONS_DIR, 'tomate-pomo.png')
+    ICON_REST_S = os.path.join(appinfo.ICONS_DIR, 'tomate-rest-s.png')
+    ICON_REST_L = os.path.join(appinfo.ICONS_DIR, 'tomate-rest-l.png')
 
     def __init__(self):
         self.indicator = AppIndicator3.Indicator.new(

--- a/test/test_event_recorder.py
+++ b/test/test_event_recorder.py
@@ -15,7 +15,7 @@ class TestEventRecorder:
     def test_app_dir_creation(self, monkeypatch, tmpdir):
         """Should create Application directory if it does not exist."""
         dir = os.path.join(str(tmpdir.realpath()), 'tomatinho')
-        monkeypatch.setattr(event_recorder.appinfo, 'APP_DIR', dir)
+        monkeypatch.setattr(event_recorder.appinfo, 'USER_DIR', dir)
 
         event_recorder.EventRecorder()
 
@@ -24,7 +24,7 @@ class TestEventRecorder:
     def test_db_file_creation(self, monkeypatch, tmpdir):
         """Should create a new DB file."""
         dir = str(tmpdir.realpath())
-        monkeypatch.setattr(event_recorder.appinfo, 'APP_DIR', dir)
+        monkeypatch.setattr(event_recorder.appinfo, 'USER_DIR', dir)
 
         event_recorder.EventRecorder()
 
@@ -33,7 +33,7 @@ class TestEventRecorder:
     def test_table_creation(self, monkeypatch, tmpdir):
         """Check if the statistics table is being created."""
         dir = str(tmpdir.realpath())
-        monkeypatch.setattr(event_recorder.appinfo, 'APP_DIR', dir)
+        monkeypatch.setattr(event_recorder.appinfo, 'USER_DIR', dir)
 
         recorder = event_recorder.EventRecorder()
 
@@ -42,7 +42,7 @@ class TestEventRecorder:
     def test_table_already_exists(self, monkeypatch, tmpdir):
         """Test what happens when the statistics table already exists."""
         dir = str(tmpdir.realpath())
-        monkeypatch.setattr(event_recorder.appinfo, 'APP_DIR', dir)
+        monkeypatch.setattr(event_recorder.appinfo, 'USER_DIR', dir)
         create_db_table(dir)
 
         assert event_recorder.EventRecorder()
@@ -51,7 +51,7 @@ class TestEventRecorder:
     def test_completed_record(self, monkeypatch, tmpdir):
         """Create a new record on the DB."""
         dir = str(tmpdir.realpath())
-        monkeypatch.setattr(event_recorder.appinfo, 'APP_DIR', dir)
+        monkeypatch.setattr(event_recorder.appinfo, 'USER_DIR', dir)
         recorder = event_recorder.EventRecorder()
 
         recorder.record(States.POMODORO, True)


### PR DESCRIPTION
Usually `setuptools` is better, but since the application is meant to be a Ubuntu package, it's better to just use `distutils` directly.

My guess is that it will also make easier to build and install `.mo` files later. 

It's important to run the setup.py with the ``--install-layout=deb`` options, otherwise the application data file will be installed on `/usr/local/`...